### PR TITLE
⚙️ [Maintenance]: Require Pester 6.x in test files

### DIFF
--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*' }
 
 Describe 'Module' {
     It 'Function: Get-PSModuleTest' {

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -1,4 +1,6 @@
-﻿Describe 'Module' {
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+
+Describe 'Module' {
     It 'Function: Get-PSModuleTest' {
         Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }


### PR DESCRIPTION
Pester tests in this module now require the Pester **6.x** major version, so every contributor and CI run resolves the same major and a new Pester major can't slip in and break the suite. The tests previously declared no framework requirement and ran on whatever Pester happened to be installed.

## Changed: tests are locked to the Pester 6.x major

Every `*.Tests.ps1` file now starts with a version-bounded requirement:

```powershell
#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*' }
```

Any Pester `6.x` satisfies it, so minor and patch releases flow in automatically while moving to a new major stays a deliberate, reviewed change. No module source or behaviour changes.

## Technical Details

- Prepends a `#Requires -Modules` statement to each test file under `tests/`; non-test files are untouched.
- `ModuleVersion = '6.0.0'` is the floor and `MaximumVersion = '6.*'` the wildcard major ceiling. Module-identity (`GUID`) pinning is intentionally omitted — it is a separate supply-chain control, not part of the lock-to-major risk appetite.
- The install side is locked to the same major in PSModule/Invoke-Pester#70. Part of the dependency-management epic PSModule/Process-PSModule#356.
